### PR TITLE
Add support for custom request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Default value: `{{type}} {{emoji}}: {{message}}`
 
 - Custom Description Prompt: A custom prompt to generate the commit description.
 
+- Request Headers: Custom headers that will be sent with each request to the Ollama server. This is useful for authentication or other purposes.
+
 ## Known Issues
 
 Sometimes, depending on the model used, it can generate quite long commit messages. However, it provides a good starting point for what the commit should be and can be manually edited to achieve the desired length.

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export const defaultConfig = {
 	language: Languages.English,
 	commitTemplate: '{{type}} {{emoji}}: {{message}}',
 	promptTemperature: 0.2,
+    requestHeaders: {},
 	emojis: {
 		feat: '✨',
 		fix: '🐛',
@@ -83,6 +84,10 @@ class Config {
 		const customCommitMessageRules = getConfig('custom.commitMessageRules')
 		const customDescriptionPrompt = getConfig('custom.descriptionPrompt')
 
+        // Load request headers
+        const requestHeaders = 
+            getConfig('request.headers') || defaultConfig.requestHeaders
+
 		return {
 			commitEmojis,
 			promptTemperature,
@@ -97,6 +102,7 @@ class Config {
 			useDescription,
 			useEmojis,
 			useLowerCase,
+            requestHeaders,
 		}
 	}
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -23,8 +23,9 @@ export async function generateStructuredCommit(
 		customTypeRules,
 		customCommitMessageRules,
 		customDescriptionPrompt,
+        requestHeaders,
 	} = config.inference
-	const ollama = new Ollama({ host: endpoint })
+	const ollama = new Ollama({ host: endpoint, headers: requestHeaders })
 
 	const typeRules =
 		customTypeRules ||

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -16,4 +16,5 @@ export type ExtensionConfig = {
 	'custom.typeRules'?: string
 	'custom.commitMessageRules'?: string
 	'custom.descriptionPrompt'?: string
+    'request.headers'?: Record<string, string>
 }


### PR DESCRIPTION
My use case is connecting to a distant Ollama server behind a protected nginx reverse proxy, which is impossible without a custom Authorization headers.

Adding custom headers will allow a broader range request customization allowed by the ollama node library underlying commitollama.