### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "commitollama",
 	"description": "AI Commits with ollama",
 	"publisher": "Commitollama",
-	"version": "3.1.2",
+	"version": "3.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/anjerodev/commitollama.git"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump version to **3.2.0** so the unreleased #145 work (current git branch in commit LLM context) ships via the Release workflow
- Apply the **Release** label so merge packages the extension, creates GitHub release `v3.2.0`, and publishes to the Marketplace

## What's included since v3.1.2
- #145 — feat: include current git branch in commit LLM context (closes #126)

## Dependabot (left open)
- #137 — still needed: bumps `@tanstack/ai` 0.51.0→0.53.0 and `@tanstack/ai-ollama` 0.10.2→0.11.1 (newer than #144)
- #142 — still needed: bumps `@types/node` 26.4.1→26.5.0 (newer than #144)

## Test plan
- [x] Local lint + `xvfb-run -a pnpm test` — **48 passing**
- [x] CI build-and-test pass
- [ ] Merge with **Release** label
- [ ] Confirm GitHub release `v3.2.0` is created with the `.vsix`
- [ ] Confirm Marketplace shows version `3.2.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf39491b-920f-5d47-9377-376a205e9f15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf39491b-920f-5d47-9377-376a205e9f15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

